### PR TITLE
v1.1.2

### DIFF
--- a/apex-trigger-handler/classes/Triggers.cls
+++ b/apex-trigger-handler/classes/Triggers.cls
@@ -38,6 +38,14 @@ public class Triggers {
         return new Manager();
     }
 
+    @TestVisible
+    private static Manager prepare(
+        TriggerOperation operationType,
+        List<SObject> oldList, List<SObject> newList) {
+        Props props = new Props(operationType, oldList, newList);
+        return new Manager(props);
+    }
+
     public class Manager {
         public final Props props { get; private set; }
         public final Context context { get; private set; }
@@ -127,53 +135,45 @@ public class Triggers {
 
         public void execute() {
             context.execute();
+            this.props.isExecuting = false;
         }
     }
 
     public class Skips {
-        private final Set<String> skipHandlerNames = new Set<String>();
+        @TestVisible
+        private final Set<Type> skippedHandlers = new Set<Type>();
 
         public void add(type handlerType) {
-            skipHandlerNames.add(getHandlerName(handlerType));
+            skippedHandlers.add(handlerType);
         }
 
         public void remove(type handlerType) {
-            skipHandlerNames.remove(getHandlerName(handlerType));
+            skippedHandlers.remove(handlerType);
         }
 
         public Boolean contains(type handlerType) {
-            return contains(getHandlerName(handlerType));
-        }
-
-        public void clear() {
-            skipHandlerNames.clear();
-        }
-
-        private Boolean contains(String handlerName) {
-            return skipHandlerNames.contains(handlerName);
-        }
-
-        private Boolean contains(Handler handler) {
-            return contains(getHandlerName(handler));
+            return skippedHandlers.contains(handlerType);
         }
 
         @TestVisible
-        private String getHandlerName(Type handlerType) {
-            String fullName = handlerType.getName();
-            if (fullName.indexOf('.') != -1) {
-                return fullName.substring(fullName.indexOf('.') + 1);
-            }
-            return fullName;
+        private Boolean contains(Handler handler) {
+            return contains(getHandlerType(handler));
         }
 
-        private String getHandlerName(Handler handler) {
+        public void clear() {
+            skippedHandlers.clear();
+        }
+
+        private Type getHandlerType(Handler handler) {
             String printName = String.valueOf(handler);
-            return printName.substring(0, printName.indexOf(':'));
+            String typeName = printName.substring(0, printName.indexOf(':'));
+            System.debug(typeName);
+            return Type.forName(typeName);
         }
     }
 
     public class Context {
-        public final Map<String, Object> state { get; private set; }
+        public final Map<Object, Object> state { get; private set; }
         public final Skips skips { get; private set; }
         public final Props props { get; private set; }
 
@@ -183,7 +183,7 @@ public class Triggers {
 
         private Context(Props props) {
             this.props = props;
-            this.state = new Map<String, Object>();
+            this.state = new Map<Object, Object>();
             this.skips = Triggers.skips;
         }
 
@@ -287,7 +287,7 @@ public class Triggers {
 
         @TestVisible
         private Props() {
-            this.isExecuting = Trigger.isExecuting;
+            this.isExecuting = true;
             this.isBefore = Trigger.isBefore;
             this.isAfter = Trigger.isAfter;
             this.isInsert = Trigger.isInsert;
@@ -301,6 +301,89 @@ public class Triggers {
             this.operationType = Trigger.operationType;
             this.size = Trigger.size;
             this.setSObjectType();
+        }
+
+        @TestVisible
+        private Props(TriggerOperation operationType, List<SObject> oldList, List<SObject> newList) {
+            this.isExecuting = true;
+            this.operationType = operationType;
+            this.isBefore = false;
+            this.isAfter = false;
+            this.isInsert = false;
+            this.isUpdate = false;
+            this.isDelete = false;
+            this.isUndelete = false;
+            switch on operationType {
+                when BEFORE_INSERT {
+                    this.isBefore = true;
+                    this.isInsert = true;
+                    this.oldList = null;
+                    this.oldMap = null;
+                    this.newList = newList;
+                    this.newMap = newList != null? new Map<Id, SObject>(newList) : null;
+                }
+                when AFTER_INSERT {
+                    this.isAfter = true;
+                    this.isInsert = true;
+                    this.oldList = null;
+                    this.oldMap = null;
+                    this.newList = newList;
+                    this.newMap = newList != null? new Map<Id, SObject>(newList) : null;
+                }
+                when BEFORE_UPDATE {
+                    this.isBefore = true;
+                    this.isUpdate = true;
+                    this.oldList = oldList;
+                    this.oldMap = oldList != null ? new Map<Id, SObject>(oldList) : null;
+                    this.newList = newList;
+                    this.newMap = newList != null? new Map<Id, SObject>(newList) : null;
+                }
+                when AFTER_UPDATE {
+                    this.isAfter = true;
+                    this.isUpdate = true;
+                    this.oldList = oldList;
+                    this.oldMap = oldList != null ? new Map<Id, SObject>(oldList) : null;
+                    this.newList = newList;
+                    this.newMap = newList != null? new Map<Id, SObject>(newList) : null;
+                }
+                when BEFORE_DELETE {
+                    this.isBefore = true;
+                    this.isDelete = true;
+                    this.oldList = oldList;
+                    this.oldMap = oldList != null ? new Map<Id, SObject>(oldList) : null;
+                    this.newList = null;
+                    this.newMap = null;
+                }
+                when AFTER_DELETE {
+                    this.isAfter = true;
+                    this.isDelete = true;
+                    this.oldList = oldList;
+                    this.oldMap = oldList != null ? new Map<Id, SObject>(oldList) : null;
+                    this.newList = null;
+                    this.newMap = null;
+                }
+                when AFTER_UNDELETE {
+                    this.isAfter = true;
+                    this.isUndelete = true;
+                    this.oldList = null;
+                    this.oldMap = null;
+                    this.newList = newList;
+                    this.newMap = newList != null? new Map<Id, SObject>(newList) : null;
+                }
+                when else {
+                }
+            }
+            this.setSize();
+            this.setSObjectType();
+        }
+
+        private void setSize() {
+            this.size = 0;
+            if (this.oldList != null) {
+                this.size = this.oldList.size();
+            } else if (this.newList != null) {
+                this.size = this.newList.size();
+            }
         }
 
         @TestVisible

--- a/apex-trigger-handler/classes/TriggersTest.cls
+++ b/apex-trigger-handler/classes/TriggersTest.cls
@@ -31,251 +31,38 @@
  */
 
 @IsTest
-private with sharing class TriggersTest {
-
-    // #region Test Handler Impls
-    class FirstHandler implements Triggers.Handler, Triggers.BeforeInsert, Triggers.AfterInsert,
-        Triggers.BeforeUpdate, Triggers.AfterUpdate, Triggers.BeforeDelete, Triggers.AfterDelete,
-        Triggers.AfterUndelete {
-        public Boolean criteria(Triggers.Context context) {
-            context.next(); // negative case, shouldn't do this
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            if (context.state.get('counter') == null) {
-                context.state.put('counter', 0);
-            }
-            System.assertEquals(0, context.state.get('counter'));
-            context.next();
-            System.assertEquals(4, context.state.get('counter'));
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterInsert(Triggers.Context context) {
-            then(context);
-        }
-
-        public void beforeUpdate(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterUpdate(Triggers.Context context) {
-            then(context);
-        }
-
-        public void beforeDelete(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterDelete(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterUndelete(Triggers.Context context) {
-            then(context);
-        }
+public with sharing class TriggersTest implements Triggers.Handler, Triggers.BeforeInsert {
+    public static String getFakeId(Schema.SObjectType objectType, Integer index) {
+        return objectType.getDescribe().getKeyPrefix()
+            + '000zzzz' // start from a large Id to avoid confliction during unit test.
+            + String.valueOf(index).leftPad(5, '0');
     }
 
-    class MainHandler implements Triggers.Handler, Triggers.BeforeInsert, Triggers.AfterInsert,
-        Triggers.BeforeUpdate, Triggers.AfterUpdate, Triggers.BeforeDelete, Triggers.AfterDelete,
-        Triggers.AfterUndelete {
-        public Boolean criteria(Triggers.Context context) {
-            context.next(); // shouldn't work in when method
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            context.state.put('counter', (Integer)context.state.get('counter') + 1);
-            context.next();
-            context.state.put('counter', (Integer)context.state.get('counter') + 1);
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterInsert(Triggers.Context context) {
-            then(context);
-        }
-
-        public void beforeUpdate(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterUpdate(Triggers.Context context) {
-            then(context);
-        }
-
-        public void beforeDelete(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterDelete(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterUndelete(Triggers.Context context) {
-            then(context);
-        }
-    }
-
-    class StopHandler implements Triggers.Handler, Triggers.BeforeInsert {
-        public Boolean criteria(Triggers.Context context) {
-            context.next(); // shouldn't work in when method
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            context.stop();
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-    }
-
-    class InactateHandler implements Triggers.Handler, Triggers.BeforeInsert {
-        public Boolean criteria(Triggers.Context context) {
-            context.next(); // shouldn't work in when method
-            return !Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            context.state.put('counter', (Integer)context.state.get('counter') + 1);
-            context.next();
-            context.state.put('counter', (Integer)context.state.get('counter') + 1);
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-    }
-
-    class AddSkipHandler implements Triggers.Handler, Triggers.BeforeInsert {
-        public Boolean criteria(Triggers.Context context) {
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            context.skips.add(SkipHandler.class);
-            context.next();
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-    }
-
-    class RemoveSkipHandler implements Triggers.Handler, Triggers.BeforeInsert {
-        public Boolean criteria(Triggers.Context context) {
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            if (context.skips.contains(SkipHandler.class)) {
-                context.skips.remove(SkipHandler.class);
-            }
-            context.next();
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-    }
-
-    class ClearSkipHandler implements Triggers.Handler, Triggers.BeforeInsert {
-        public Boolean criteria(Triggers.Context context) {
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            context.skips.clear();
-            context.next();
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-    }
-
-    class SkipHandler implements Triggers.Handler, Triggers.BeforeInsert {
-        public Boolean criteria(Triggers.Context context) {
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            context.state.put('counter', (Integer)context.state.get('counter') + 1);
-            context.next();
-            context.state.put('counter', (Integer)context.state.get('counter') + 1);
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-    }
-
-    class LastHandler implements Triggers.Handler, Triggers.BeforeInsert, Triggers.AfterInsert,
-        Triggers.BeforeUpdate, Triggers.AfterUpdate, Triggers.BeforeDelete, Triggers.AfterDelete,
-        Triggers.AfterUndelete {
-        public Boolean criteria(Triggers.Context context) {
-            context.next(); // shouldn't work in when method
-            return Triggers.WHEN_ALWAYS;
-        }
-
-        private void then(Triggers.Context context) {
-            System.assertEquals(2, context.state.get('counter'));
-            context.next();
-            System.assertEquals(2, context.state.get('counter'));
-        }
-
-        public void beforeInsert(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterInsert(Triggers.Context context) {
-            then(context);
-        }
-
-        public void beforeUpdate(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterUpdate(Triggers.Context context) {
-            then(context);
-        }
-
-        public void beforeDelete(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterDelete(Triggers.Context context) {
-            then(context);
-        }
-
-        public void afterUndelete(Triggers.Context context) {
-            then(context);
-        }
-    }
-    // #endregion
-
-    @TestSetup
-    static void makeData(){
-        insert new List<Account> {
-            new Account(Name = 'Account 1', Description = 'Account 1', BillingCity = 'New York'),
-            new Account(Name = 'Account 2', Description = 'Account 2', BillingCity = 'New York'),
-            new Account(Name = 'Account 3', Description = 'Account 3', BillingCity = 'New York')
+    static List<Account> createAccounts() {
+        return new List<Account> {
+            new Account(Id = getFakeId(Account.SObjectType, 1), Name = 'Account 1', Description = 'Account 1', BillingCity = 'New York'),
+            new Account(Id = getFakeId(Account.SObjectType, 2), Name = 'Account 2', Description = 'Account 2', BillingCity = 'New York'),
+            new Account(Id = getFakeId(Account.SObjectType, 3), Name = 'Account 3', Description = 'Account 3', BillingCity = 'New York')
         };
     }
 
     @IsTest
     static void testSkips_getHandlerName_ByType() {
         Triggers.Skips skips = new Triggers.Skips();
-        String className = skips.getHandlerName(String.class);
-        System.assertEquals('String', className);
+        skips.add(String.class);
+        System.assertEquals(true, skips.contains(String.class));
+
+        skips.remove(String.class);
+        System.assertEquals(0, skips.skippedHandlers.size());
+
+        skips.add(TriggersTest.TriggersTest.class);
+        System.assertEquals(true, skips.contains(TriggersTest.class));
+
+        skips.clear();
+        System.assertEquals(0, skips.skippedHandlers.size());
+
+        skips.add(TriggersTest.class);
+        System.assertEquals(true, skips.contains(new TriggersTest()));
     }
 
     @IsTest
@@ -303,23 +90,40 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_Stop_BeforeInsert() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = true;
-        triggerManager.props.isAfter = false;
-        triggerManager.props.isInsert = true;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.BEFORE_INSERT;
+        Triggers.Manager triggerManager = Triggers.prepare(
+            TriggerOperation.BEFORE_INSERT, new List<Account>(), new List<Account>());
+        triggerManager.beforeInsert()
+            .bind(new FirstHandler())
+            .bind(new MainHandler())
+            .bind(new MainHandler())
+            .bind(new StopHandler())
+            .bind(new MainHandler())
+            .bind(new LastHandler())
+        .execute();
 
-        triggerManager
-            .beforeInsert()
-                .bind(new FirstHandler())
-                .bind(new MainHandler())
-                .bind(new MainHandler())
-                .bind(new StopHandler())
-                .bind(new MainHandler())
-                .bind(new LastHandler())
+        System.assertEquals(4, triggerManager.context.state.get('counter'));
+    }
+
+    @IsTest
+    static void testBinding_Stop_AfterInsert() {
+        Triggers.Manager triggerManager = Triggers.prepare(
+            TriggerOperation.AFTER_INSERT, new List<Account> {
+                new Account(Id = TriggersTest.getFakeId(Account.SObjectType, 1)),
+                new Account(Id = TriggersTest.getFakeId(Account.SObjectType, 2)),
+                new Account(Id = TriggersTest.getFakeId(Account.SObjectType, 3))
+            }, new List<Account> {
+                new Account(Id = TriggersTest.getFakeId(Account.SObjectType, 1)),
+                new Account(Id = TriggersTest.getFakeId(Account.SObjectType, 2)),
+                new Account(Id = TriggersTest.getFakeId(Account.SObjectType, 3))
+            });
+
+        triggerManager.afterInsert()
+            .bind(new FirstHandler())
+            .bind(new MainHandler())
+            .bind(new MainHandler())
+            .bind(new StopHandler())
+            .bind(new MainHandler())
+            .bind(new LastHandler())
         .execute();
 
         System.assertEquals(4, triggerManager.context.state.get('counter'));
@@ -327,71 +131,45 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_Inactive_BeforeInsert() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = true;
-        triggerManager.props.isAfter = false;
-        triggerManager.props.isInsert = true;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.BEFORE_INSERT;
-
-        triggerManager
-            .beforeInsert()
-                .bind(new FirstHandler())
-                .bind(new MainHandler())
-                .bind(new InactateHandler())
-                .bind(new MainHandler())
-                .bind(new LastHandler())
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.BEFORE_INSERT, null, null);
+        triggerManager.beforeInsert()
+            .bind(new FirstHandler())
+            .bind(new MainHandler())
+            .bind(new InactiveHandler())
+            .bind(new MainHandler())
+            .bind(new LastHandler())
         .execute();
 
         System.assertEquals(4, triggerManager.context.state.get('counter'));
     }
 
     @IsTest
-    static void testBinding_Skip_BeforeInsert() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = true;
-        triggerManager.props.isAfter = false;
-        triggerManager.props.isInsert = true;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.BEFORE_INSERT;
-
-        triggerManager
-            .beforeInsert()
-                .bind(new FirstHandler())
-                .bind(new MainHandler())
-                .bind(new AddSkipHandler())
-                .bind(new SkipHandler())
-                .bind(new RemoveSkipHandler())
-                .bind(new SkipHandler())
-                .bind(new LastHandler())
+    static void testBinding_Skip_Remove() {
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.BEFORE_INSERT, null, null);
+        triggerManager.beforeInsert()
+            .bind(new FirstHandler())
+            .bind(new MainHandler())
+            .bind(new AddSkippedHandler())
+            .bind(new TriggersTest())
+            .bind(new RemoveSkippedHandler())
+            .bind(new TriggersTest())
+            .bind(new LastHandler())
         .execute();
 
         System.assertEquals(4, triggerManager.context.state.get('counter'));
     }
 
     @IsTest
-    static void testBinding_Clear_BeforeInsert() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = true;
-        triggerManager.props.isAfter = false;
-        triggerManager.props.isInsert = true;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.BEFORE_INSERT;
-
+    static void testBinding_Skip_Clear() {
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.BEFORE_INSERT, null, null);
         triggerManager
             .beforeInsert()
                 .bind(new FirstHandler())
                 .bind(new MainHandler())
-                .bind(new AddSkipHandler())
-                .bind(new SkipHandler())
-                .bind(new ClearSkipHandler())
-                .bind(new SkipHandler())
+                .bind(new AddSkippedHandler())
+                .bind(new TriggersTest())
+                .bind(new ClearSkippedHandler())
+                .bind(new TriggersTest())
                 .bind(new LastHandler())
         .execute();
 
@@ -401,15 +179,7 @@ private with sharing class TriggersTest {
     // #region Test State
     @IsTest
     static void testBinding_State_BeforeInsert() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = true;
-        triggerManager.props.isAfter = false;
-        triggerManager.props.isInsert = true;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.BEFORE_INSERT;
-
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.BEFORE_INSERT, null, null);
         triggerManager
             .beforeInsert()
                 .bind(new FirstHandler())
@@ -423,15 +193,7 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_State_AfterInsert() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = false;
-        triggerManager.props.isAfter = true;
-        triggerManager.props.isInsert = true;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.AFTER_INSERT;
-
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.AFTER_INSERT, null, null);
         triggerManager
             .afterInsert()
                 .bind(new FirstHandler())
@@ -445,15 +207,8 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_State_BeforeUpdate() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = true;
-        triggerManager.props.isAfter = false;
-        triggerManager.props.isInsert = false;
-        triggerManager.props.isUpdate = true;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.BEFORE_UPDATE;
-
+        Triggers.Manager triggerManager = Triggers.prepare(
+            TriggerOperation.BEFORE_UPDATE, new List<Account>(), new List<Account>());
         triggerManager
             .beforeUpdate()
                 .bind(new FirstHandler())
@@ -467,15 +222,7 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_State_AfterUpdate() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = false;
-        triggerManager.props.isAfter = true;
-        triggerManager.props.isInsert = false;
-        triggerManager.props.isUpdate = true;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.AFTER_UPDATE;
-
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.AFTER_UPDATE, null, null);
         triggerManager
             .afterUpdate()
                 .bind(new FirstHandler())
@@ -489,15 +236,7 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_State_BeforeDelete() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = true;
-        triggerManager.props.isAfter = false;
-        triggerManager.props.isInsert = false;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = true;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.BEFORE_DELETE;
-
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.BEFORE_DELETE, null, null);
         triggerManager
             .beforeDelete()
                 .bind(new FirstHandler())
@@ -511,15 +250,7 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_State_AfterDelete() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = false;
-        triggerManager.props.isAfter = true;
-        triggerManager.props.isInsert = false;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = true;
-        triggerManager.props.isUndelete = false;
-        triggerManager.props.operationType = TriggerOperation.AFTER_DELETE;
-
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.AFTER_DELETE, null, null);
         triggerManager
             .afterDelete()
                 .bind(new FirstHandler())
@@ -533,15 +264,7 @@ private with sharing class TriggersTest {
 
     @IsTest
     static void testBinding_State_AfterUndelete() {
-        Triggers.Manager triggerManager = Triggers.prepare();
-        triggerManager.props.isBefore = false;
-        triggerManager.props.isAfter = true;
-        triggerManager.props.isInsert = false;
-        triggerManager.props.isUpdate = false;
-        triggerManager.props.isDelete = false;
-        triggerManager.props.isUndelete = true;
-        triggerManager.props.operationType = TriggerOperation.AFTER_UNDELETE;
-
+        Triggers.Manager triggerManager = Triggers.prepare(TriggerOperation.AFTER_UNDELETE, null, null);
         triggerManager
             .afterUndelete()
                 .bind(new FirstHandler())
@@ -563,7 +286,7 @@ private with sharing class TriggersTest {
         props.isDelete = false;
         props.isUndelete = false;
 
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.newList = accounts;
         props.newMap = new Map<Id, Account>(accounts);
 
@@ -620,7 +343,7 @@ private with sharing class TriggersTest {
         props.isDelete = false;
         props.isUndelete = false;
 
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         props.newList = accounts;
@@ -640,7 +363,7 @@ private with sharing class TriggersTest {
         props.isUpdate = true;
         props.isDelete = false;
         props.isUndelete = false;
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         List<Account> newAccounts = accounts.deepClone();
@@ -668,7 +391,7 @@ private with sharing class TriggersTest {
         props.isDelete = false;
         props.isUndelete = false;
 
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         props.newList = accounts;
@@ -688,7 +411,7 @@ private with sharing class TriggersTest {
         props.isUpdate = true;
         props.isDelete = false;
         props.isUndelete = false;
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         List<Account> newAccounts = accounts.deepClone();
@@ -714,7 +437,7 @@ private with sharing class TriggersTest {
         props.isUpdate = true;
         props.isDelete = false;
         props.isUndelete = false;
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         List<Account> newAccounts = accounts.deepClone();
@@ -742,7 +465,7 @@ private with sharing class TriggersTest {
         props.isDelete = false;
         props.isUndelete = false;
 
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         props.newList = accounts;
@@ -762,7 +485,7 @@ private with sharing class TriggersTest {
         props.isUpdate = true;
         props.isDelete = false;
         props.isUndelete = false;
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         List<Account> newAccounts = accounts.deepClone();
@@ -790,7 +513,7 @@ private with sharing class TriggersTest {
         props.isUpdate = true;
         props.isDelete = false;
         props.isUndelete = false;
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         List<Account> newAccounts = accounts.deepClone();
@@ -816,7 +539,7 @@ private with sharing class TriggersTest {
         props.isUpdate = true;
         props.isDelete = false;
         props.isUndelete = false;
-        List<Account> accounts = [SELECT Id, Name, Description, BillingCity FROM Account Limit 3];
+        List<Account> accounts = createAccounts();
         props.oldList = accounts;
         props.oldMap = new Map<Id, Account>(accounts);
         List<Account> newAccounts = accounts.deepClone();
@@ -838,6 +561,238 @@ private with sharing class TriggersTest {
 
         System.assertEquals(1, changedIds.size());
         System.assertEquals(true, isChanged);
+    }
+    // #endregion
+
+
+    // #region Test Handler Impls
+    // TriggersTest is treated as a handler to be skipped, because inner class cannot be reflected
+    // from an instance back to type properly.
+    public Boolean criteria(Triggers.Context context) {
+        return Triggers.WHEN_ALWAYS;
+    }
+
+    public void beforeInsert(Triggers.Context context) {
+        context.state.put('counter', (Integer)context.state.get('counter') + 1);
+        context.next();
+        context.state.put('counter', (Integer)context.state.get('counter') + 1);
+    }
+
+    public class FirstHandler implements Triggers.Handler, Triggers.BeforeInsert, Triggers.AfterInsert,
+        Triggers.BeforeUpdate, Triggers.AfterUpdate, Triggers.BeforeDelete, Triggers.AfterDelete,
+        Triggers.AfterUndelete {
+        public Boolean criteria(Triggers.Context context) {
+            context.next(); // negative case, shouldn't do this
+            return Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            if (context.state.get('counter') == null) {
+                context.state.put('counter', 0);
+            }
+            System.assertEquals(0, context.state.get('counter'));
+            context.next();
+            System.assertEquals(4, context.state.get('counter'));
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterInsert(Triggers.Context context) {
+            then(context);
+        }
+
+        public void beforeUpdate(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterUpdate(Triggers.Context context) {
+            then(context);
+        }
+
+        public void beforeDelete(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterDelete(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterUndelete(Triggers.Context context) {
+            then(context);
+        }
+    }
+
+    public class MainHandler implements Triggers.Handler, Triggers.BeforeInsert, Triggers.AfterInsert,
+        Triggers.BeforeUpdate, Triggers.AfterUpdate, Triggers.BeforeDelete, Triggers.AfterDelete,
+        Triggers.AfterUndelete {
+        public Boolean criteria(Triggers.Context context) {
+            context.next(); // shouldn't work in when method
+            return Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            context.state.put('counter', (Integer)context.state.get('counter') + 1);
+            context.next();
+            context.state.put('counter', (Integer)context.state.get('counter') + 1);
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterInsert(Triggers.Context context) {
+            then(context);
+        }
+
+        public void beforeUpdate(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterUpdate(Triggers.Context context) {
+            then(context);
+        }
+
+        public void beforeDelete(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterDelete(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterUndelete(Triggers.Context context) {
+            then(context);
+        }
+    }
+
+    public class StopHandler implements Triggers.Handler, Triggers.BeforeInsert, Triggers.AfterInsert {
+        public Boolean criteria(Triggers.Context context) {
+            context.next(); // shouldn't work in when method
+            return Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            context.stop();
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterInsert(Triggers.Context context) {
+            then(context);
+        }
+    }
+
+    public class InactiveHandler implements Triggers.Handler, Triggers.BeforeInsert {
+        public Boolean criteria(Triggers.Context context) {
+            context.next(); // negative test, shouldn't work in when method
+            context.next();
+            context.next();
+            return !Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            context.state.put('counter', (Integer)context.state.get('counter') + 1);
+            context.next();
+            context.state.put('counter', (Integer)context.state.get('counter') + 1);
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+    }
+
+    public class AddSkippedHandler implements Triggers.Handler, Triggers.BeforeInsert {
+        public Boolean criteria(Triggers.Context context) {
+            return Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            context.skips.add(TriggersTest.class);
+            context.next();
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+    }
+
+    public class RemoveSkippedHandler implements Triggers.Handler, Triggers.BeforeInsert {
+        public Boolean criteria(Triggers.Context context) {
+            return Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            if (context.skips.contains(TriggersTest.class)) {
+                context.skips.remove(TriggersTest.class);
+            }
+            context.next();
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+    }
+
+    public class ClearSkippedHandler implements Triggers.Handler, Triggers.BeforeInsert {
+        public Boolean criteria(Triggers.Context context) {
+            return Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            context.skips.clear();
+            context.next();
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+    }
+
+    public class LastHandler implements Triggers.Handler, Triggers.BeforeInsert, Triggers.AfterInsert,
+        Triggers.BeforeUpdate, Triggers.AfterUpdate, Triggers.BeforeDelete, Triggers.AfterDelete,
+        Triggers.AfterUndelete {
+        public Boolean criteria(Triggers.Context context) {
+            context.next(); // shouldn't work in when method
+            return Triggers.WHEN_ALWAYS;
+        }
+
+        private void then(Triggers.Context context) {
+            System.assertEquals(2, context.state.get('counter'));
+            context.next();
+            System.assertEquals(2, context.state.get('counter'));
+        }
+
+        public void beforeInsert(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterInsert(Triggers.Context context) {
+            then(context);
+        }
+
+        public void beforeUpdate(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterUpdate(Triggers.Context context) {
+            then(context);
+        }
+
+        public void beforeDelete(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterDelete(Triggers.Context context) {
+            then(context);
+        }
+
+        public void afterUndelete(Triggers.Context context) {
+            then(context);
+        }
     }
     // #endregion
 }


### PR DESCRIPTION
1. Eliminate any DML statements in test class, so the library can be installed in any org.
2. **Unit Test Mock**: Add a private but `@TestVisible` helper method to mock the handler tests, so we don't need to do any DMLs in order to trigger the handlers.